### PR TITLE
fix" Update first rule 

### DIFF
--- a/green_nailao/yara
+++ b/green_nailao/yara
@@ -49,9 +49,9 @@ rule Windows_Ransomware_NailaoLoader_0 : malware {
             7? ??
         }
     condition:
-      uint16(0) == 0x5a4d
-      and filesize < 300KB
-      and 2 of them
+        uint16(0) == 0x5a4d
+        and filesize < 300KB
+        and 2 of them
 }
 
 

--- a/green_nailao/yara
+++ b/green_nailao/yara
@@ -49,7 +49,9 @@ rule Windows_Ransomware_NailaoLoader_0 : malware {
             7? ??
         }
     condition:
-        2 of them and uint16(0) == 0x5A4D
+      uint16(0) == 0x5a4d
+      and filesize < 300KB
+      and 2 of them
 }
 
 


### PR DESCRIPTION
It is good to add a size check because it will help avoid false positives (FPs).

FP Hashes:
cf4cd2c7f7e10d62927ccb41b98a5b190e1659b89ec6b2ba26ca0b734700466e  
ce1a4b632c1db31c60e15fca9be9acc6cae15737f66c01a4830352e8defb3a9e  
e39670782e63b38f3f17f8a59c463b69e8bf6639f2466cbc07780b663d87ae64  
55505666e353093fcbc8e1d1373f0760e314c03b17e64c70a8edb39cf4b345f6  
2425c2ee50f40b0e835c88194b75e6b38671fe414cedd39d561465fab752f213  

Also related to Locker ransomware.
It is best to avoid relying on the following, as they can change across different versions:
1- Filenames
2- Extensions
3- Mutex names
I recommend looking at wide strings, as there are some consistent ones that would be useful for this rule.

like 
1 - SOFTWARE\Microsoft\Windows\CurrentVersion\Run
2- *** Encrypt [%s] error with code 0x%x
3- *** Decrypt [%s] error with code 0x%x
4- *** Excute [%s] error with code 0x%x
5- OK Excute [%s] OK
6- OK Encrypt [%s]
7- OK Decrypt [%s]




